### PR TITLE
Feat/walk

### DIFF
--- a/src/main/java/com/kakao/termproject/config/SecurityConfig.java
+++ b/src/main/java/com/kakao/termproject/config/SecurityConfig.java
@@ -1,0 +1,30 @@
+package com.kakao.termproject.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+  @Bean
+  public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+    http
+      .httpBasic(AbstractHttpConfigurer::disable)
+      .csrf(AbstractHttpConfigurer::disable)
+      .formLogin(AbstractHttpConfigurer::disable)
+      .authorizeHttpRequests((auth) -> auth
+        .requestMatchers("/ws/**", "/api/dev/**").permitAll()
+        .requestMatchers("/", "/index.html", "/error").permitAll()
+        .anyRequest().permitAll())
+      .sessionManagement((session) ->
+        session.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+
+    return http.build();
+  }
+}

--- a/src/main/java/com/kakao/termproject/exception/ErrorResult.java
+++ b/src/main/java/com/kakao/termproject/exception/ErrorResult.java
@@ -1,0 +1,7 @@
+package com.kakao.termproject.common;
+
+import org.springframework.http.HttpStatus;
+
+public record ErrorResult(HttpStatus status, String message) {
+
+}

--- a/src/main/java/com/kakao/termproject/exception/ErrorResult.java
+++ b/src/main/java/com/kakao/termproject/exception/ErrorResult.java
@@ -1,7 +1,11 @@
-package com.kakao.termproject.common;
+package com.kakao.termproject.exception;
 
 import org.springframework.http.HttpStatus;
 
-public record ErrorResult(HttpStatus status, String message) {
+public record ErrorResult(
+  HttpStatus status,
+  String message,
+  StackTraceElement[] stackTraceElements
+) {
 
 }

--- a/src/main/java/com/kakao/termproject/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/kakao/termproject/exception/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.kakao.termproject.exception;
 
 import com.kakao.termproject.exception.custom.DataNotFoundException;
+import com.kakao.termproject.exception.custom.JsonParseException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -20,6 +21,19 @@ public class GlobalExceptionHandler {
         e.getStackTrace()
       ),
       HttpStatus.NOT_FOUND
+    );
+  }
+
+  @ResponseStatus(HttpStatus.BAD_REQUEST)
+  @ExceptionHandler(value = JsonParseException.class)
+  public ResponseEntity<ErrorResult> jsonProcessingException(JsonParseException e) {
+    return new ResponseEntity<>(
+      new ErrorResult(
+        HttpStatus.BAD_REQUEST,
+        e.getMessage(),
+        e.getStackTrace()
+      ),
+      HttpStatus.BAD_REQUEST
     );
   }
 }

--- a/src/main/java/com/kakao/termproject/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/kakao/termproject/exception/GlobalExceptionHandler.java
@@ -1,8 +1,25 @@
-package com.kakao.termproject.common;
+package com.kakao.termproject.exception;
 
+import com.kakao.termproject.exception.custom.DataNotFoundException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
+  @ResponseStatus(HttpStatus.NOT_FOUND)
+  @ExceptionHandler(value = DataNotFoundException.class)
+  public ResponseEntity<ErrorResult> dataNotFound(DataNotFoundException e) {
+    return new ResponseEntity<>(
+      new ErrorResult(
+        HttpStatus.NOT_FOUND,
+        e.getMessage(),
+        e.getStackTrace()
+      ),
+      HttpStatus.NOT_FOUND
+    );
+  }
 }

--- a/src/main/java/com/kakao/termproject/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/kakao/termproject/exception/GlobalExceptionHandler.java
@@ -1,0 +1,8 @@
+package com.kakao.termproject.common;
+
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+}

--- a/src/main/java/com/kakao/termproject/exception/custom/DataNotFoundException.java
+++ b/src/main/java/com/kakao/termproject/exception/custom/DataNotFoundException.java
@@ -1,4 +1,4 @@
-package com.kakao.termproject.common.exceptions;
+package com.kakao.termproject.exception.custom;
 
 public class DataNotFoundException extends RuntimeException {
 

--- a/src/main/java/com/kakao/termproject/exception/custom/DataNotFoundException.java
+++ b/src/main/java/com/kakao/termproject/exception/custom/DataNotFoundException.java
@@ -1,0 +1,8 @@
+package com.kakao.termproject.common.exceptions;
+
+public class DataNotFoundException extends RuntimeException {
+
+  public DataNotFoundException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/com/kakao/termproject/exception/custom/JsonParseException.java
+++ b/src/main/java/com/kakao/termproject/exception/custom/JsonParseException.java
@@ -1,4 +1,8 @@
 package com.kakao.termproject.exception.custom;
 
-public class JsonParseException {
+public class JsonParseException extends RuntimeException {
+
+  public JsonParseException(String message) {
+    super(message);
+  }
 }

--- a/src/main/java/com/kakao/termproject/exception/custom/JsonParseException.java
+++ b/src/main/java/com/kakao/termproject/exception/custom/JsonParseException.java
@@ -1,0 +1,4 @@
+package com.kakao.termproject.exception.custom;
+
+public class JsonParseException {
+}

--- a/src/main/java/com/kakao/termproject/walk/controller/WalkController.java
+++ b/src/main/java/com/kakao/termproject/walk/controller/WalkController.java
@@ -4,9 +4,12 @@ import com.kakao.termproject.walk.dto.WalkData;
 import com.kakao.termproject.walk.service.WalkService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -22,5 +25,12 @@ public class WalkController {
   public ResponseEntity<WalkData> getWalk(@PathVariable Long walkId) {
     log.info("get Walk data for walkId: {}", walkId);
     return ResponseEntity.ok(walkService.getWalkById(walkId));
+  }
+
+  @PostMapping
+  public ResponseEntity<Long> walk(@RequestBody WalkData data) {
+    log.info("Walk save Request");
+    return ResponseEntity.status(HttpStatus.CREATED)
+      .body(walkService.saveWalk(data));
   }
 }

--- a/src/main/java/com/kakao/termproject/walk/controller/WalkController.java
+++ b/src/main/java/com/kakao/termproject/walk/controller/WalkController.java
@@ -1,0 +1,4 @@
+package com.kakao.termproject.walk.controller;
+
+public class WalkController {
+}

--- a/src/main/java/com/kakao/termproject/walk/controller/WalkController.java
+++ b/src/main/java/com/kakao/termproject/walk/controller/WalkController.java
@@ -1,4 +1,26 @@
 package com.kakao.termproject.walk.controller;
 
+import com.kakao.termproject.walk.dto.WalkData;
+import com.kakao.termproject.walk.service.WalkService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/walk")
+@RequiredArgsConstructor
+@Slf4j
 public class WalkController {
+
+  private final WalkService walkService;
+
+  @GetMapping("/{walkId}")
+  public ResponseEntity<WalkData> getWalk(@PathVariable Long walkId) {
+    log.info("get Walk data for walkId: {}", walkId);
+    return ResponseEntity.ok(walkService.getWalkById(walkId));
+  }
 }

--- a/src/main/java/com/kakao/termproject/walk/domain/Walk.java
+++ b/src/main/java/com/kakao/termproject/walk/domain/Walk.java
@@ -1,4 +1,22 @@
 package com.kakao.termproject.walk.domain;
 
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor
+@Getter
 public class Walk {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(columnDefinition = "TEXT")
+  private String walk;
 }

--- a/src/main/java/com/kakao/termproject/walk/domain/Walk.java
+++ b/src/main/java/com/kakao/termproject/walk/domain/Walk.java
@@ -1,0 +1,4 @@
+package com.kakao.termproject.walk.domain;
+
+public class Walk {
+}

--- a/src/main/java/com/kakao/termproject/walk/domain/Walk.java
+++ b/src/main/java/com/kakao/termproject/walk/domain/Walk.java
@@ -19,4 +19,8 @@ public class Walk {
 
   @Column(columnDefinition = "TEXT")
   private String walk;
+
+  public Walk(String walk) {
+    this.walk = walk;
+  }
 }

--- a/src/main/java/com/kakao/termproject/walk/dto/WalkData.java
+++ b/src/main/java/com/kakao/termproject/walk/dto/WalkData.java
@@ -1,0 +1,4 @@
+package com.kakao.termproject.walk.dto;
+
+public record WalkRequest(Routes routes) {
+}

--- a/src/main/java/com/kakao/termproject/walk/dto/WalkData.java
+++ b/src/main/java/com/kakao/termproject/walk/dto/WalkData.java
@@ -1,4 +1,11 @@
 package com.kakao.termproject.walk.dto;
 
-public record WalkRequest(Routes routes) {
+public record WalkData(Routes routes) {
+
+  record Routes(Sections sections) {
+
+    record Sections(double[] departure, double[] arrival, Integer distance, Integer duration) {
+
+    }
+  }
 }

--- a/src/main/java/com/kakao/termproject/walk/dto/WalkData.java
+++ b/src/main/java/com/kakao/termproject/walk/dto/WalkData.java
@@ -1,11 +1,37 @@
 package com.kakao.termproject.walk.dto;
 
-public record WalkData(Routes routes) {
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
-  record Routes(Sections sections) {
+public record WalkData(@JsonProperty("routes") Routes routes) {
 
-    record Sections(double[] departure, double[] arrival, Integer distance, Integer duration) {
+  public record Routes(@JsonProperty("sections") Sections sections) {
 
+    public record Sections(
+      @JsonProperty("departure") Departure departure,
+      @JsonProperty("arrival") Arrival arrival,
+      @JsonProperty("distance") Integer distance,
+      @JsonProperty("duration") Integer duration
+    ) {
+
+      public record Departure(
+        @JsonProperty("lng") double lng,
+        @JsonProperty("lat") double lat
+      ) {
+
+      }
+
+      public record Arrival(
+        @JsonProperty("lng") double lng,
+        @JsonProperty("lat") double lat
+      ) {
+
+      }
     }
+  }
+
+  @JsonCreator
+  public WalkData(@JsonProperty("routes") Routes routes) {
+    this.routes = routes;
   }
 }

--- a/src/main/java/com/kakao/termproject/walk/dto/WalkResponse.java
+++ b/src/main/java/com/kakao/termproject/walk/dto/WalkResponse.java
@@ -1,0 +1,5 @@
+package com.kakao.termproject.walk.dto;
+
+public record WalkResponse(Long id, String walk) {
+
+}

--- a/src/main/java/com/kakao/termproject/walk/repository/WalkRepository.java
+++ b/src/main/java/com/kakao/termproject/walk/repository/WalkRepository.java
@@ -1,0 +1,4 @@
+package com.kakao.termproject.walk.repository;
+
+public interface WalkRepository {
+}

--- a/src/main/java/com/kakao/termproject/walk/repository/WalkRepository.java
+++ b/src/main/java/com/kakao/termproject/walk/repository/WalkRepository.java
@@ -1,4 +1,8 @@
 package com.kakao.termproject.walk.repository;
 
-public interface WalkRepository {
+import com.kakao.termproject.walk.domain.Walk;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface WalkRepository extends JpaRepository<Walk, Long> {
+
 }

--- a/src/main/java/com/kakao/termproject/walk/service/WalkService.java
+++ b/src/main/java/com/kakao/termproject/walk/service/WalkService.java
@@ -1,0 +1,4 @@
+package com.kakao.termproject.walk.service;
+
+public class WalkService {
+}

--- a/src/main/java/com/kakao/termproject/walk/service/WalkService.java
+++ b/src/main/java/com/kakao/termproject/walk/service/WalkService.java
@@ -1,12 +1,15 @@
 package com.kakao.termproject.walk.service;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.kakao.termproject.exception.custom.DataNotFoundException;
+import com.kakao.termproject.exception.custom.JsonParseException;
 import com.kakao.termproject.walk.domain.Walk;
 import com.kakao.termproject.walk.dto.WalkData;
 import com.kakao.termproject.walk.repository.WalkRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -16,10 +19,28 @@ public class WalkService {
 
   private static final ObjectMapper objectMapper = new ObjectMapper();
 
+  @Transactional(readOnly = true)
   public WalkData getWalkById(Long walkId) {
-    Walk walk = walkRepository.findById(walkId)
-      .orElseThrow(() -> new DataNotFoundException("해당되는 id의 산책 경로가 존재하지 않습니다."));
+    try {
+      Walk walk = walkRepository.findById(walkId)
+        .orElseThrow(() -> new DataNotFoundException("해당되는 id의 산책 경로가 존재하지 않습니다."));
 
-    return objectMapper.convertValue(walk.getWalk(), WalkData.class);
+      return objectMapper.readValue(walk.getWalk(), WalkData.class);
+    } catch (JsonProcessingException e) {
+      throw new JsonParseException("산책 경로 데이터 직렬화에 실패하였습니다.");
+    }
+  }
+
+  @Transactional
+  public Long saveWalk(WalkData walkData) {
+    try {
+      String data = objectMapper.writeValueAsString(walkData);
+
+      Walk walk = walkRepository.save(new Walk(data));
+
+      return walk.getId();
+    } catch (JsonProcessingException e) {
+      throw new JsonParseException("산책 경로 데이터 역직렬화에 실패하였습니다.");
+    }
   }
 }

--- a/src/main/java/com/kakao/termproject/walk/service/WalkService.java
+++ b/src/main/java/com/kakao/termproject/walk/service/WalkService.java
@@ -1,4 +1,25 @@
 package com.kakao.termproject.walk.service;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kakao.termproject.exception.custom.DataNotFoundException;
+import com.kakao.termproject.walk.domain.Walk;
+import com.kakao.termproject.walk.dto.WalkData;
+import com.kakao.termproject.walk.repository.WalkRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
 public class WalkService {
+
+  private final WalkRepository walkRepository;
+
+  private static final ObjectMapper objectMapper = new ObjectMapper();
+
+  public WalkData getWalkById(Long walkId) {
+    Walk walk = walkRepository.findById(walkId)
+      .orElseThrow(() -> new DataNotFoundException("해당되는 id의 산책 경로가 존재하지 않습니다."));
+
+    return objectMapper.convertValue(walk.getWalk(), WalkData.class);
+  }
 }


### PR DESCRIPTION
close #2 

### Config
``` java
        .requestMatchers("/", "/index.html", "/error").permitAll()
        .anyRequest().permitAll())
```
SecurityConfig를 작성했습니다. 단순히 테스트를 위해 작성한 것이기 때문에 우선 모든 경로에 대한 요청을 허용하도록 했습니다.
추후에 accessToken 등 인증/인가 기능이 추가되면 회의를 통해서 다시 작성할 예정입니다.

### Exception
``` bash
src/main/java/com/kakao/termproject/exception
├── ErrorResult.java
├── GlobalExceptionHandler.java
└── custom
    ├── DataNotFoundException.java
    └── JsonParseException.java
```
오류 관련 디렉토리를 만들었습니다. 해당 디렉토리의 구조는 위와 같습니다.

### Walk
아직 데이터에 대해 구체적인 이야기가 없었기 때문에, 출발 및 도착 위치, 이동거리, 이동시간을 포함하여 데이터를 주고 받는 형태로 작성했습니다.

POST 요청의 반환값은 우선 Long으로 설정하여 생성된 데이터의 ID를 반환하도록 했는데, 프론트측의 요청이 있는 경우 ID와 DB에 저장된 형태의 경로 정보를 같이 제공할 예정입니다.