### PR TITLE
feat(weather): 날씨 상세 정보 조회

### DIFF
--- a/src/main/java/com/kakao/termproject/weather/RestTemplateConfig.java
+++ b/src/main/java/com/kakao/termproject/weather/RestTemplateConfig.java
@@ -1,0 +1,21 @@
+package com.kakao.termproject.weather;
+
+import java.time.Duration;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfig {
+
+  @Bean
+  public RestTemplate restTemplate() {
+    return new RestTemplateBuilder()
+        .errorHandler(new RestTemplateResponseErrorHandler())
+        .connectTimeout(Duration.ofSeconds(3))
+        .readTimeout(Duration.ofSeconds(5))
+        .build();
+  }
+
+}

--- a/src/main/java/com/kakao/termproject/weather/RestTemplateResponseErrorHandler.java
+++ b/src/main/java/com/kakao/termproject/weather/RestTemplateResponseErrorHandler.java
@@ -1,0 +1,37 @@
+package com.kakao.termproject.weather;
+
+import com.kakao.termproject.weather.exception.ClientErrorException;
+import com.kakao.termproject.weather.exception.ServerErrorException;
+import java.io.IOException;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.ResponseErrorHandler;
+
+@Component
+public class RestTemplateResponseErrorHandler implements ResponseErrorHandler {
+
+  @Override
+  public boolean hasError(ClientHttpResponse response) throws IOException {
+    return response.getStatusCode().isError();
+  }
+
+  @Override
+  public void handleError(URI url, HttpMethod method, ClientHttpResponse response)
+      throws IOException {
+    HttpStatusCode statusCode = response.getStatusCode();
+    String responseBody = new String(response.getBody().readAllBytes(), StandardCharsets.UTF_8);
+
+    if (statusCode.is5xxServerError()) {
+      throw new ServerErrorException(statusCode, responseBody);
+    }
+
+    if (statusCode.is4xxClientError()) {
+      throw new ClientErrorException(statusCode, responseBody);
+    }
+  }
+
+}

--- a/src/main/java/com/kakao/termproject/weather/WeatherCondition.java
+++ b/src/main/java/com/kakao/termproject/weather/WeatherCondition.java
@@ -1,0 +1,19 @@
+package com.kakao.termproject.weather;
+
+public enum WeatherCondition {
+  CLEAR_DAY, CLOUDY_DAY, RAINY_DAY, SNOWY_DAY, WINDY_DAY,
+  CLEAR_NIGHT, CLOUDY_NIGHT, RAINY_NIGHT, SNOWY_NIGHT, WINDY_NIGHT;
+
+  public static WeatherCondition from(String main, String pod) {
+    boolean isDay = "d".equalsIgnoreCase(pod);
+
+    return switch (main.toLowerCase()) {
+      case "clear" -> isDay ? CLEAR_DAY : CLEAR_NIGHT;
+      case "clouds" -> isDay ? CLOUDY_DAY : CLOUDY_NIGHT;
+      case "rain" -> isDay ? RAINY_DAY : RAINY_NIGHT;
+      case "snow" -> isDay ? SNOWY_DAY : SNOWY_NIGHT;
+      case "wind" -> isDay ? WINDY_DAY : WINDY_NIGHT;
+      default -> throw new IllegalArgumentException("Unknown weather main: " + main);
+    };
+  }
+}

--- a/src/main/java/com/kakao/termproject/weather/WeatherController.java
+++ b/src/main/java/com/kakao/termproject/weather/WeatherController.java
@@ -1,0 +1,31 @@
+package com.kakao.termproject.weather;
+
+
+import com.kakao.termproject.weather.dto.WeatherResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/weather")
+public class WeatherController {
+
+  private final WeatherService weatherService;
+
+  public WeatherController(WeatherService weatherService) {
+    this.weatherService = weatherService;
+  }
+
+  //날씨 상세 정보
+  @GetMapping
+  public ResponseEntity<WeatherResponse> getWeatherDetail(
+      @RequestParam double lat, @RequestParam double lon, @RequestParam int cnt
+  ) {
+    WeatherResponse response = weatherService.getWeatherDetail(lat, lon, cnt);
+
+    return ResponseEntity.ok(response);
+  }
+
+}

--- a/src/main/java/com/kakao/termproject/weather/WeatherService.java
+++ b/src/main/java/com/kakao/termproject/weather/WeatherService.java
@@ -1,0 +1,50 @@
+package com.kakao.termproject.weather;
+
+import com.kakao.termproject.weather.dto.WeatherApiResponse;
+import com.kakao.termproject.weather.dto.WeatherResponse;
+import java.net.URI;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@Service
+public class WeatherService {
+
+  @Value("${openweathermap.api.key}")
+  private String apiKey;
+
+  private final RestTemplate restTemplate;
+
+  public WeatherService(RestTemplate restTemplate) {
+    this.restTemplate = restTemplate;
+  }
+
+  public WeatherResponse getWeatherDetail(double lat, double lon, int cnt) {
+    URI uri = UriComponentsBuilder
+        .fromHttpUrl("https://api.openweathermap.org/data/2.5/forecast")
+        .queryParam("lat", lat)
+        .queryParam("lon", lon)
+        .queryParam("units", "metric")
+        .queryParam("appid", apiKey)
+        .queryParam("cnt", cnt)
+        .build()
+        .toUri();
+
+    WeatherApiResponse apiResponse = restTemplate.getForObject(uri, WeatherApiResponse.class);
+
+    List<WeatherResponse.WeatherItem> items = apiResponse.list().stream()
+        .map(item -> new WeatherResponse.WeatherItem(
+            item.dateTime(),
+            WeatherCondition.from(item.weather().get(0).main(), item.sys().pod()),
+            item.main().temp(),
+            item.precipitationProbability(),
+            item.wind().speed()
+        ))
+        .collect(Collectors.toList());
+
+    return new WeatherResponse(items);
+  }
+}

--- a/src/main/java/com/kakao/termproject/weather/dto/WeatherApiResponse.java
+++ b/src/main/java/com/kakao/termproject/weather/dto/WeatherApiResponse.java
@@ -1,0 +1,45 @@
+package com.kakao.termproject.weather.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+
+public record WeatherApiResponse(
+    List<WeatherList> list
+) {
+
+  public record WeatherList(
+      @JsonProperty("dt_txt") String dateTime,
+      Main main,
+      List<Weather> weather,
+      @JsonProperty("pop") double precipitationProbability,
+      Wind wind,
+      Sys sys
+  ) {
+
+  }
+
+  public record Main(
+      double temp
+  ) {
+
+  }
+
+  public record Weather(
+      String main,
+      String description
+  ) {
+
+  }
+
+  public record Wind(
+      double speed
+  ) {
+
+  }
+
+  public record Sys(
+      String pod //"d" 또는 "n". day or night
+  ) {
+
+  }
+}

--- a/src/main/java/com/kakao/termproject/weather/dto/WeatherResponse.java
+++ b/src/main/java/com/kakao/termproject/weather/dto/WeatherResponse.java
@@ -1,0 +1,17 @@
+package com.kakao.termproject.weather.dto;
+
+import com.kakao.termproject.weather.WeatherCondition;
+import java.util.List;
+
+public record WeatherResponse(List<WeatherItem> items) {
+
+  public record WeatherItem(
+      String time,
+      WeatherCondition condition,
+      double temperature,
+      double precipitationProbability, //강수확률 (0~1)
+      double windSpeed
+  ) {
+
+  }
+}

--- a/src/main/java/com/kakao/termproject/weather/exception/ClientErrorException.java
+++ b/src/main/java/com/kakao/termproject/weather/exception/ClientErrorException.java
@@ -1,0 +1,13 @@
+package com.kakao.termproject.weather.exception;
+
+import org.springframework.http.HttpStatusCode;
+
+public class ClientErrorException extends RuntimeException {
+
+  private final HttpStatusCode statusCode;
+
+  public ClientErrorException(HttpStatusCode statusCode, String message) {
+    super("Client error " + statusCode + ": " + message);
+    this.statusCode = statusCode;
+  }
+}

--- a/src/main/java/com/kakao/termproject/weather/exception/ServerErrorException.java
+++ b/src/main/java/com/kakao/termproject/weather/exception/ServerErrorException.java
@@ -1,0 +1,13 @@
+package com.kakao.termproject.weather.exception;
+
+import org.springframework.http.HttpStatusCode;
+
+public class ServerErrorException extends RuntimeException {
+
+  private final HttpStatusCode statusCode;
+
+  public ServerErrorException(HttpStatusCode statusCode, String message) {
+    super("Server error " + statusCode + ": " + message);
+    this.statusCode = statusCode;
+  }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,3 +12,7 @@ spring:
       hibernate:
         default_batch_fetch_size: 100
     defer-datasource-initialization: true
+
+openweathermap:
+  api:
+    key: ${OPENWEATHERMAP_API_KEY}


### PR DESCRIPTION
close #7 

## Weather
`OpenWeatherMap 5 day / 3 hour forecast data API`를 활용하여 특정 위치(lat, lon)의 날씨 정보를 조회하는 REST API를 구현하였습니다.
현재는 3시간 단위로 날씨를 조회 가능하고, `Hourly Forecast 4 days API`는 유료지만 Free for students라고 하여 다음 주에 매 시간 별 조회가 가능하도록 변경해보겠습니다.

`GET /api/weather`
요청 파라미터: `lat(위도)`, `lon(경도)`, `cnt(조회할 날씨 개수)`
반환: `WeatherResponse(시간, 날씨, 온도, 강수확률, 풍속)`

<img width="600" height="600" alt="image" src="https://github.com/user-attachments/assets/8cd2ada6-c681-4ede-aa63-54d552dee779" />


