### PR TITLE
fix: fixing the problem of servers showing only http protocol

### DIFF
--- a/src/main/java/com/kakao/termproject/config/OpenApiConfig.java
+++ b/src/main/java/com/kakao/termproject/config/OpenApiConfig.java
@@ -1,0 +1,16 @@
+package com.kakao.termproject.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.servers.Server;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenApiConfig {
+
+  @Bean
+  public OpenAPI customOpenAPI() {
+    return new OpenAPI()
+      .addServersItem(new Server().url("https://spring-gift.store/"));
+  }
+}


### PR DESCRIPTION
- swagger에서 서버가 http로만 표시되어 cors 정책에 걸리던 문제를 해결하고자 https 프로토콜 서버를 추가하였습니다.