### PR TITLE
feat(swagger): add authorization header to enable API call tests

### DIFF
--- a/src/main/java/com/kakao/termproject/config/OpenApiConfig.java
+++ b/src/main/java/com/kakao/termproject/config/OpenApiConfig.java
@@ -1,11 +1,21 @@
 package com.kakao.termproject.config;
 
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeIn;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
+import io.swagger.v3.oas.annotations.security.SecurityScheme;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.servers.Server;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
+@SecurityScheme(
+  name = "Authorization",
+  type = SecuritySchemeType.HTTP,
+  scheme = "bearer",
+  bearerFormat = "JWT",
+  in = SecuritySchemeIn.HEADER
+)
 public class OpenApiConfig {
 
   @Bean


### PR DESCRIPTION
close #40 
- swagger에 header 옵션을 추가하여 register/login 등 인증/인가가 필요한 API의 테스트도 정상적으로 수행할 수 있도록 하였습니다.