### PR TITLE
Refactor/post

### DIFF
--- a/src/main/java/com/kakao/termproject/TermprojectApplication.java
+++ b/src/main/java/com/kakao/termproject/TermprojectApplication.java
@@ -3,7 +3,9 @@ package com.kakao.termproject;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @ConfigurationPropertiesScan
 @SpringBootApplication
 public class TermprojectApplication {

--- a/src/main/java/com/kakao/termproject/image/dto/ImageResponse.java
+++ b/src/main/java/com/kakao/termproject/image/dto/ImageResponse.java
@@ -1,7 +1,5 @@
 package com.kakao.termproject.image.dto;
 
-import java.util.List;
-
-public record ImageResponse(Long postId, List<String> images) {
+public record ImageResponse(Long postId) {
 
 }

--- a/src/main/java/com/kakao/termproject/image/dto/UploadRequest.java
+++ b/src/main/java/com/kakao/termproject/image/dto/UploadRequest.java
@@ -1,0 +1,7 @@
+package com.kakao.termproject.image.dto;
+
+import org.springframework.web.multipart.MultipartFile;
+
+public record UploadRequest(String fileName, MultipartFile file) {
+
+}

--- a/src/main/java/com/kakao/termproject/image/event/DeleteEvent.java
+++ b/src/main/java/com/kakao/termproject/image/event/DeleteEvent.java
@@ -1,0 +1,7 @@
+package com.kakao.termproject.image.event;
+
+import java.util.List;
+
+public record DeleteEvent(List<String> images) {
+
+}

--- a/src/main/java/com/kakao/termproject/image/event/UploadEvent.java
+++ b/src/main/java/com/kakao/termproject/image/event/UploadEvent.java
@@ -1,0 +1,8 @@
+package com.kakao.termproject.image.event;
+
+import com.kakao.termproject.image.dto.UploadRequest;
+import java.util.List;
+
+public record UploadEvent(List<UploadRequest> uploadRequests) {
+
+}

--- a/src/main/java/com/kakao/termproject/image/properties/ImageProperties.java
+++ b/src/main/java/com/kakao/termproject/image/properties/ImageProperties.java
@@ -1,0 +1,14 @@
+package com.kakao.termproject.image.properties;
+
+import java.util.List;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "image")
+public record ImageProperties(
+  List<String> allowedExtensions,
+  String filePath,
+  Long maxFileSize,
+  String bucketName
+) {
+
+}

--- a/src/main/java/com/kakao/termproject/image/service/ImageService.java
+++ b/src/main/java/com/kakao/termproject/image/service/ImageService.java
@@ -16,7 +16,7 @@ import org.springframework.web.multipart.MultipartFile;
 @RequiredArgsConstructor
 public class ImageService {
 
-  private final S3Service s3Service;
+  private final UploadService uploadService;
   private final ImageRepository imageRepository;
   private final PostRepository postRepository;
 
@@ -25,7 +25,7 @@ public class ImageService {
     Post post = postRepository.findById(postId)
       .orElseThrow(() -> new DataNotFoundException("게시글이 존재하지 않습니다."));
 
-    List<String> images = s3Service.upload(files);
+    List<String> images = uploadService.upload(files);
 
     List<Image> imageEntities = images.stream()
       .map(imageName -> new Image(imageName, post))
@@ -46,7 +46,7 @@ public class ImageService {
       .map(Image::getName)
       .toList();
 
-    return s3Service.getImages(images);
+    return uploadService.getImages(images);
   }
 
   @Transactional
@@ -59,7 +59,7 @@ public class ImageService {
       .map(Image::getName)
       .toList();
 
-    s3Service.delete(images);
+    uploadService.delete(images);
     imageRepository.deleteByPost(post);
   }
 }

--- a/src/main/java/com/kakao/termproject/image/service/ImageService.java
+++ b/src/main/java/com/kakao/termproject/image/service/ImageService.java
@@ -1,39 +1,62 @@
 package com.kakao.termproject.image.service;
 
+import com.kakao.termproject.exception.custom.BadFormatException;
 import com.kakao.termproject.exception.custom.DataNotFoundException;
+import com.kakao.termproject.exception.custom.FailedToUploadException;
 import com.kakao.termproject.image.domain.Image;
 import com.kakao.termproject.image.dto.ImageResponse;
+import com.kakao.termproject.image.dto.UploadRequest;
+import com.kakao.termproject.image.event.DeleteEvent;
+import com.kakao.termproject.image.event.UploadEvent;
+import com.kakao.termproject.image.properties.ImageProperties;
 import com.kakao.termproject.image.repository.ImageRepository;
 import com.kakao.termproject.post.domain.Post;
 import com.kakao.termproject.post.repository.PostRepository;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
 import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @RequiredArgsConstructor
 public class ImageService {
 
-  private final UploadService uploadService;
   private final ImageRepository imageRepository;
   private final PostRepository postRepository;
+  private final ApplicationEventPublisher eventPublisher;
+  private final UploadService uploadService;
+  private final ImageProperties imageProperties;
 
   @Transactional
   public ImageResponse upload(Long postId, List<MultipartFile> files) {
     Post post = postRepository.findById(postId)
       .orElseThrow(() -> new DataNotFoundException("게시글이 존재하지 않습니다."));
 
-    List<String> images = uploadService.upload(files);
+    List<UploadRequest> images = new ArrayList<>();
+
+    files.forEach(file -> {
+      if (file.getSize() > imageProperties.maxFileSize()) {
+        throw new FailedToUploadException("파일 크기는 최대 10MB를 넘길 수 없습니다.");
+      }
+
+      String newFileName = createUniqueName(file.getOriginalFilename());
+      images.add(new UploadRequest(newFileName, file));
+    });
 
     List<Image> imageEntities = images.stream()
-      .map(imageName -> new Image(imageName, post))
+      .map(image -> new Image(image.fileName(), post))
       .toList();
 
     imageRepository.saveAll(imageEntities);
 
-    return new ImageResponse(postId, images);
+    eventPublisher.publishEvent(new UploadEvent(images));
+
+    return new ImageResponse(postId);
   }
 
   @Transactional(readOnly = true)
@@ -59,7 +82,21 @@ public class ImageService {
       .map(Image::getName)
       .toList();
 
-    uploadService.delete(images);
+    eventPublisher.publishEvent(new DeleteEvent(images));
+
     imageRepository.deleteByPost(post);
+  }
+
+  private String createUniqueName(String fileName) {
+    return UUID.randomUUID().toString().concat(getExtension(fileName));
+  }
+
+  private String getExtension(String fileName) {
+    String ext = StringUtils.getFilenameExtension(fileName);
+    if (ext == null || !imageProperties.allowedExtensions().contains("." + ext)) {
+      throw new BadFormatException();
+    }
+
+    return "." + ext;
   }
 }

--- a/src/main/java/com/kakao/termproject/image/service/S3Service.java
+++ b/src/main/java/com/kakao/termproject/image/service/S3Service.java
@@ -2,11 +2,12 @@ package com.kakao.termproject.image.service;
 
 import com.kakao.termproject.exception.custom.BadFormatException;
 import com.kakao.termproject.exception.custom.FailedToUploadException;
+import com.kakao.termproject.image.properties.ImageProperties;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
-import org.springframework.beans.factory.annotation.Value;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 import software.amazon.awssdk.core.exception.SdkException;
@@ -18,25 +19,17 @@ import software.amazon.awssdk.services.s3.model.ObjectIdentifier;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
 @Service
+@RequiredArgsConstructor
 public class S3Service {
 
   private final S3Client s3Client;
-  private final String bucketName;
-
-  private static final List<String> ALLOWED_EXTENSIONS = List.of(".jpg", ".jpeg", ".png", ".webp");
-  private static final String FILE_PATH = "images/";
-  private static final Long MAX_FILE_SIZE = 10 * 1024 * 1024L;
-
-  public S3Service(S3Client s3Client, @Value("${spring.cloud.aws.s3.bucket}") String bucketName) {
-    this.s3Client = s3Client;
-    this.bucketName = bucketName;
-  }
+  private final ImageProperties imageProperties;
 
   public List<String> upload(List<MultipartFile> files) {
     List<String> results = new ArrayList<>();
 
     files.forEach(file -> {
-      if (file.getSize() > MAX_FILE_SIZE) {
+      if (file.getSize() > imageProperties.maxFileSize()) {
         throw new FailedToUploadException("파일 크기는 최대 10MB를 넘길 수 없습니다.");
       }
 
@@ -45,8 +38,8 @@ public class S3Service {
       try {
         s3Client.putObject(
           PutObjectRequest.builder()
-            .bucket(bucketName)
-            .key(FILE_PATH + fileName)
+            .bucket(imageProperties.bucketName())
+            .key(imageProperties.filePath() + fileName)
             .contentType(file.getContentType())
             .build(),
           RequestBody.fromInputStream(file.getInputStream(), file.getSize())
@@ -69,7 +62,7 @@ public class S3Service {
 
   private String getExtension(String fileName) {
     String ext = fileName.substring(fileName.lastIndexOf("."));
-    if (fileName.lastIndexOf(".") == -1 || !ALLOWED_EXTENSIONS.contains(ext)) {
+    if (fileName.lastIndexOf(".") == -1 || !imageProperties.allowedExtensions().contains(ext)) {
       throw new BadFormatException();
     }
 
@@ -79,19 +72,20 @@ public class S3Service {
   public List<String> getImages(List<String> fileNames) {
     return fileNames.stream()
       .map(fileName -> s3Client.utilities()
-        .getUrl(url -> url.bucket(bucketName).key(FILE_PATH + fileName)).toString())
+        .getUrl(url -> url.bucket(imageProperties.bucketName())
+          .key(imageProperties.filePath() + fileName)).toString())
       .toList();
   }
 
   public void delete(List<String> files) {
     List<ObjectIdentifier> objects = files.stream()
       .map(file -> ObjectIdentifier.builder()
-        .key(FILE_PATH + file)
+        .key(imageProperties.filePath() + file)
         .build())
       .toList();
 
     DeleteObjectsRequest deleteObjectsRequest = DeleteObjectsRequest.builder()
-      .bucket(bucketName)
+      .bucket(imageProperties.bucketName())
       .delete(Delete.builder()
         .objects(objects)
         .build())

--- a/src/main/java/com/kakao/termproject/image/service/UploadService.java
+++ b/src/main/java/com/kakao/termproject/image/service/UploadService.java
@@ -20,7 +20,7 @@ import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
 @Service
 @RequiredArgsConstructor
-public class S3Service {
+public class UploadService {
 
   private final S3Client s3Client;
   private final ImageProperties imageProperties;

--- a/src/main/java/com/kakao/termproject/image/service/UploadService.java
+++ b/src/main/java/com/kakao/termproject/image/service/UploadService.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
 import org.springframework.web.multipart.MultipartFile;
 import software.amazon.awssdk.core.exception.SdkException;
 import software.amazon.awssdk.core.sync.RequestBody;
@@ -61,12 +62,12 @@ public class UploadService {
   }
 
   private String getExtension(String fileName) {
-    String ext = fileName.substring(fileName.lastIndexOf("."));
-    if (fileName.lastIndexOf(".") == -1 || !imageProperties.allowedExtensions().contains(ext)) {
+    String ext = StringUtils.getFilenameExtension(fileName);
+    if (ext == null || !imageProperties.allowedExtensions().contains("." + ext)) {
       throw new BadFormatException();
     }
 
-    return ext;
+    return "." + ext;
   }
 
   public List<String> getImages(List<String> fileNames) {

--- a/src/main/java/com/kakao/termproject/image/service/UploadService.java
+++ b/src/main/java/com/kakao/termproject/image/service/UploadService.java
@@ -1,15 +1,15 @@
 package com.kakao.termproject.image.service;
 
-import com.kakao.termproject.exception.custom.BadFormatException;
 import com.kakao.termproject.exception.custom.FailedToUploadException;
+import com.kakao.termproject.image.dto.UploadRequest;
+import com.kakao.termproject.image.event.DeleteEvent;
+import com.kakao.termproject.image.event.UploadEvent;
 import com.kakao.termproject.image.properties.ImageProperties;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.List;
-import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import org.springframework.util.StringUtils;
+import org.springframework.transaction.event.TransactionalEventListener;
 import org.springframework.web.multipart.MultipartFile;
 import software.amazon.awssdk.core.exception.SdkException;
 import software.amazon.awssdk.core.sync.RequestBody;
@@ -26,15 +26,13 @@ public class UploadService {
   private final S3Client s3Client;
   private final ImageProperties imageProperties;
 
-  public List<String> upload(List<MultipartFile> files) {
-    List<String> results = new ArrayList<>();
+  @TransactionalEventListener
+  public void upload(UploadEvent event) {
+    List<UploadRequest> images = event.uploadRequests();
 
-    files.forEach(file -> {
-      if (file.getSize() > imageProperties.maxFileSize()) {
-        throw new FailedToUploadException("파일 크기는 최대 10MB를 넘길 수 없습니다.");
-      }
-
-      String fileName = createUniqueName(file.getOriginalFilename());
+    images.forEach(image -> {
+      String fileName = image.fileName();
+      MultipartFile file = image.file();
 
       try {
         s3Client.putObject(
@@ -50,24 +48,7 @@ public class UploadService {
       } catch (SdkException e) {
         throw new FailedToUploadException("S3 업로드 중 오류가 발생했습니다.");
       }
-
-      results.add(fileName);
     });
-
-    return results;
-  }
-
-  private String createUniqueName(String fileName) {
-    return UUID.randomUUID().toString().concat(getExtension(fileName));
-  }
-
-  private String getExtension(String fileName) {
-    String ext = StringUtils.getFilenameExtension(fileName);
-    if (ext == null || !imageProperties.allowedExtensions().contains("." + ext)) {
-      throw new BadFormatException();
-    }
-
-    return "." + ext;
   }
 
   public List<String> getImages(List<String> fileNames) {
@@ -78,7 +59,10 @@ public class UploadService {
       .toList();
   }
 
-  public void delete(List<String> files) {
+  @TransactionalEventListener
+  public void delete(DeleteEvent event) {
+    List<String> files = event.images();
+
     List<ObjectIdentifier> objects = files.stream()
       .map(file -> ObjectIdentifier.builder()
         .key(imageProperties.filePath() + file)

--- a/src/main/java/com/kakao/termproject/post/controller/PostController.java
+++ b/src/main/java/com/kakao/termproject/post/controller/PostController.java
@@ -37,14 +37,12 @@ public class PostController {
     @AuthenticationPrincipal Member member,
     @RequestBody @Valid PostRequest postRequest
   ) {
-    log.info("Post request");
     return ResponseEntity.status(HttpStatus.CREATED)
       .body(postService.savePost(postRequest, member));
   }
 
   @GetMapping("/{id}")
   public ResponseEntity<PostResponse> getPost(@PathVariable Long id) {
-    log.info("get post id: {}", id);
     return ResponseEntity.ok(postService.getPost(id));
   }
 
@@ -53,10 +51,7 @@ public class PostController {
     @RequestParam(required = false) Long memberId,
     Pageable pageable
   ) {
-    log.info("get posts");
-
     if (memberId != null) {
-      log.info("memberId: {}", memberId);
       return ResponseEntity.ok(postService.getPostsByMemberId(memberId, pageable));
     }
 
@@ -68,7 +63,6 @@ public class PostController {
     @AuthenticationPrincipal Member member,
     Pageable pageable
   ) {
-    log.info("get my posts");
     return ResponseEntity.ok(postService.getMyPosts(member, pageable));
   }
 
@@ -77,7 +71,6 @@ public class PostController {
     @AuthenticationPrincipal Member member,
     @PathVariable Long id,
     @RequestBody @Valid PostRequest postRequest) {
-    log.info("update post id: {}", id);
     return ResponseEntity.ok(postService.updatePost(id, postRequest, member));
   }
 
@@ -85,7 +78,6 @@ public class PostController {
   public ResponseEntity<Void> deletePost(
     @AuthenticationPrincipal Member member,
     @PathVariable Long id) {
-    log.info("delete post id: {}", id);
     postService.deletePost(id, member);
     return ResponseEntity.noContent().build();
   }

--- a/src/main/java/com/kakao/termproject/post/domain/Post.java
+++ b/src/main/java/com/kakao/termproject/post/domain/Post.java
@@ -50,4 +50,8 @@ public class Post {
     this.title = title;
     this.content = content;
   }
+
+  public boolean isOwner(Member member) {
+    return this.member.getId().equals(member.getId());
+  }
 }

--- a/src/main/java/com/kakao/termproject/post/dto/PostRequest.java
+++ b/src/main/java/com/kakao/termproject/post/dto/PostRequest.java
@@ -5,10 +5,11 @@ import jakarta.validation.constraints.Size;
 
 public record PostRequest(
   @NotBlank
+  @Size(min = 1, max = 20, message = "제목은 최대 20글자까지 입력 가능합니다.")
   String title,
 
   @NotBlank
-  @Size(min = 10, message = "10자 이상 입력해주세요.")
+  @Size(min = 10, max = 250, message = "내용은 10자 이상 250자 이하로 입력해주세요.")
   String content
 ) {
 

--- a/src/main/java/com/kakao/termproject/post/service/PostService.java
+++ b/src/main/java/com/kakao/termproject/post/service/PostService.java
@@ -66,7 +66,7 @@ public class PostService {
     Post post = postRepository.findById(id)
       .orElseThrow(() -> new DataNotFoundException("해당 게시글을 찾을 수 없습니다."));
 
-    if (!post.getMember().getId().equals(member.getId())) {
+    if (!post.isOwner(member)) {
       throw new OwnerMismatchException("접근 권한이 없습니다.");
     }
 

--- a/src/main/java/com/kakao/termproject/walk/controller/WalkController.java
+++ b/src/main/java/com/kakao/termproject/walk/controller/WalkController.java
@@ -51,7 +51,6 @@ public class WalkController {
   public ResponseEntity<WalkResponse> getWalk(
     @AuthenticationPrincipal Member member
   ) {
-    log.info("get Walk data for member: {}", member);
     return ResponseEntity.ok(walkService.getWalk(member));
   }
 
@@ -73,7 +72,6 @@ public class WalkController {
   public ResponseEntity<WalkResponse> saveWalk(
     @AuthenticationPrincipal Member member,
     @RequestBody WalkData data) {
-    log.info("Walk save Request");
     return ResponseEntity.status(HttpStatus.CREATED)
       .body(walkService.saveWalk(member, data));
   }
@@ -96,7 +94,6 @@ public class WalkController {
   public ResponseEntity<WalkResponse> updateWalk(
     @AuthenticationPrincipal Member member,
     @RequestBody WalkData data) {
-    log.info("Walk update Request");
     return ResponseEntity.ok(walkService.updateWalk(member, data));
   }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,8 +8,6 @@ spring:
         secret-key: ${SECRET_KEY}
       region:
         static: ap-northeast-2
-      s3:
-        bucket: termproject-s3
   config:
     import: aws-parameterstore:/project/v1/
   data:
@@ -52,3 +50,13 @@ springdoc:
   cache:
     disabled: true
   show-actuator: false
+
+image:
+  allowed-extensions:
+    - .jpg
+    - .jpeg
+    - .png
+    - .webp
+  file-path: images/
+  max-file-size: 10000000
+  bucket-name: termproject-s3


### PR DESCRIPTION
리뷰에 따라 코드를 수정하였습니다.
- post에서 제목과 내용에 최대 글자수 제한을 적용하였습니다.
- getter 사용을 피하기 위해 서비스 레이어에 있던 비교 로직을 도메인 레이어로 옮겼습니다.
- s3Service에서 사용하던 상수들을 프로퍼티로 관리하기 위해 yml 파일로 이동시켰습니다.
- s3Service의 이름을 UploadService로 변경하였습니다.
- `@EnableJpaAuditing`의 부재로 createdAt, uploadedAt이 null로 저장되었던 문제를 해결하였습니다.
- AI 코드 리뷰에 따라 lastIndexOf 메서드를 제거하고, StringUtils 클래스의 getFilenameExtension 메서드를 활용하였습니다.
- 트랜잭션이 적용된 ImageService에서 s3Service의 업로드 메서드를 호출했던 부분을 `@TransactionalEventListener`로 처리하도록 변경하였습니다.
    - 파일 이름의 중복을 피하기 위해서 UUID로 파일 이름을 변경 후 업로드, 저장을 하고 있기 때문에 event 객체에 파일 이름과 파일을 담아 전달하였습니다.
    - delete의 경우에도 업로드와 같은 문제가 발생할 수 있기 때문에 이벤트 처리하도록 하였습니다.
- walkController, postController의 불필요한 로그를 제거하였습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * New centralized image configuration for file management.

* **Improvements**
  * Enhanced post validation: titles now limited to 20 characters maximum; content must be 10-250 characters.
  * Streamlined image upload and deletion workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->